### PR TITLE
Set correct sbt cache directories

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,15 @@ scala:
   - 2.13.1
 jdk:
   - openjdk8
+before_cache:
+  - rm -fv $HOME/.ivy2/.sbt.ivy.lock
+  - find $HOME/.ivy2/cache -name "ivydata-*.properties" -print -delete
+  - find $HOME/.sbt -name "*.lock" -print -delete
 cache:
   directories:
-    - $HOME/sbt-cache/ivy/cache
-    - $HOME/sbt-cache/boot
-    - $HOME/sbt-cache/sbtboot
-    - $HOME/sbt-cache/target
+    - $HOME/.cache/coursier
+    - $HOME/.ivy2/cache
+    - $HOME/.sbt
 script:
   - sbt ++$TRAVIS_SCALA_VERSION scalafmtCheck scalafmtSbtCheck test:scalafmtCheck clean coverage test
 after_success:


### PR DESCRIPTION
Current configuration does not cache anything as sbt is not configured to write its output `sbt-cache`. This results in much longer travis builds cause of fetching project dependencies and sbt itself.

This custom `sbt-cache` directory back from gitlab times is not needed anymore (not sure why it was used before). We should be just fine with sbt defaults