### PR TITLE
fix migration table name in flyway module

### DIFF
--- a/app/utils/FlywayModule.scala
+++ b/app/utils/FlywayModule.scala
@@ -42,10 +42,21 @@ class FlywayInitializer @Inject() (
   if (environment.mode == Mode.Prod) {
     try {
       val dbSettings = config.dbSettings
-      val flyway = new Flyway()
-      flyway.setLocations("migrations/common", "migrations/postgres")
-      flyway.setDataSource(dbSettings.url, dbSettings.user, dbSettings.password)
-      flyway.setOutOfOrder(true)
+      val flyway = Flyway
+        .configure()
+        .locations(
+          "migrations/common",
+          "migrations/postgres"
+        )
+        .dataSource(
+          dbSettings.url,
+          dbSettings.user,
+          dbSettings.password
+        )
+        .table("schema_version")
+        .outOfOrder(true)
+        .load()
+
       flyway.migrate()
     } catch {
       case e: FlywayException => log.error("Can't apply migrations", e)

--- a/build.sbt
+++ b/build.sbt
@@ -30,7 +30,7 @@ libraryDependencies ++= Seq(
   "org.scalaz" %% "scalaz-core" % "7.2.30",
   "com.google.apis" % "google-api-services-sheets" % "v4-rev473-1.22.0",
   "com.google.apis" % "google-api-services-drive" % "v3-rev74-1.22.0",
-  "org.flywaydb" % "flyway-core" % "4.1.2",
+  "org.flywaydb" % "flyway-core" % "6.3.3",
   "io.scalaland" %% "chimney" % "0.4.1",
   "commons-io" % "commons-io" % "2.6",
   filters,

--- a/test/models/dao/BaseDaoTest.scala
+++ b/test/models/dao/BaseDaoTest.scala
@@ -41,13 +41,14 @@ trait BaseDaoTest
   private val dbUser = ConfigFactory.load.getString("slick.dbs.default.db.user")
   private val dbPass = ConfigFactory.load.getString("slick.dbs.default.db.password")
 
-  private val flyway = new Flyway()
-
   private val dbSetupDestination = new DriverManagerDestination(dbUrl, dbUser, dbPass)
 
   override def beforeEach(): Unit = {
-    flyway.setLocations("migrations/common", "migrations/h2")
-    flyway.setDataSource(dbUrl, dbUser, dbPass)
+    val flyway = Flyway
+      .configure()
+      .locations("migrations/common", "migrations/h2")
+      .dataSource(dbUrl, dbUser, dbPass)
+      .load()
     flyway.clean()
     flyway.migrate()
     executeFixtureOperations(dbSetupDestination)


### PR DESCRIPTION
Flyway changed it default name for table where migrations are stored in version 5. To keep this code compatible with previous o360 setups, we set this table name to the old default value